### PR TITLE
Fix reccurent OSError which happen frequently when handeling 500 simu…

### DIFF
--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -241,27 +241,21 @@ class ProtectFile:
                 break
 
             except OSError:
-                print(f'__init__ -> OSError: {self.lockfile.exists()=}')
                 # An error happen while trying to generate the Lockfile. This raise an 
                 # OSError: [Errno 5] Input/output error!
                 self._wait(wait)
                 if self.lockfile.exists():
 #                 if max_lock_time is not None and self.lockfile.exists():
                     try:
-                        print(f'__init__ -> OSError:  try 1 begin')
                         kill_lock = False
                         try:
-                            print(f'__init__ -> OSError:  try 2 begin')
                             with self.lockfile.open('r') as fid:
                                 info = json.load(fid)
-                            print(f'__init__ -> OSError:  try 2 succed')
                         except:
-                            print(f'__init__ -> OSError:  try 2 fail')
                             continue
                         if self._testing:
                             # This is only for tests, to be able to kill the process
                             time.sleep(1)
-                        print(f'__init__ -> OSError:  {info=}')
                         if 'free_after' in info and int(info['free_after']) > 0 \
                         and int(info['free_after']) < time.time():
                             # We free the original process by deleting the lockfile
@@ -270,7 +264,6 @@ class ProtectFile:
                             # gets to use the file; which is the intended behaviour
                             # (first one wins).
                             kill_lock = True
-                        print(f'__init__ -> OSError:  {kill_lock=}')
                         if kill_lock:
                             self.lockfile.unlink()
                             self._print_debug("init",f"freed {self.lockfile} because "
@@ -282,31 +275,24 @@ class ProtectFile:
                 pass
 
             except FileNotFoundError:
-                print('__init__ -> FileNotFoundError:')
                 # Lockfile could not be created, wait and try again
                 self._wait(wait)
                 pass
 
             except FileExistsError:
-                print(f'__init__ -> FileExistsError:  {max_lock_time=}')
                 # Lockfile exists, wait and try again
                 self._wait(wait)
                 if max_lock_time is not None:
                     try:
-                        print(f'__init__ -> FileExistsError:  try 1 begin')
                         kill_lock = False
                         try:
-                            print(f'__init__ -> FileExistsError:  try 2 begin')
                             with self.lockfile.open('r') as fid:
                                 info = json.load(fid)
-                            print(f'__init__ -> FileExistsError:  try 2 succed')
                         except:
-                            print(f'__init__ -> FileExistsError:  try 2 fail')
                             continue
                         if self._testing:
                             # This is only for tests, to be able to kill the process
                             time.sleep(1)
-                        print(f'__init__ -> FileExistsError:  {info=}')
                         if 'free_after' in info and int(info['free_after']) > 0 \
                         and int(info['free_after']) < time.time():
                             # We free the original process by deleting the lockfile
@@ -325,7 +311,6 @@ class ProtectFile:
                         pass
 
             except PermissionError:
-                print('__init__ -> PermissionError:')
                 # Special case: we can still access eos files when permission has expired, using `eos`
                 if isinstance(self.file, EosPath):
                     try:

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -32,6 +32,7 @@ atexit.register(exit_handler)
 # This one should handle those exceptions.
 def kill_handler(*args):
     exit_handler()
+    print(args)
     sys.exit(0)
 signal.signal(signal.SIGINT, kill_handler)
 signal.signal(signal.SIGTERM, kill_handler)

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -6,6 +6,7 @@ Last update 23/03/2024 - F.F. Van der Veken
 import sys
 import atexit
 import signal
+import traceback
 import datetime
 import hashlib
 import io
@@ -30,9 +31,10 @@ def exit_handler():
 atexit.register(exit_handler)
 
 # This one should handle those exceptions.
-def kill_handler(*args):
+def kill_handler(signum, frame):
     exit_handler()
-    print(args)
+    print(f"Signal {signum} has been raised.\n\n BackTrack:")
+    traceback.print_stack(frame)
     sys.exit(0)
 signal.signal(signal.SIGINT, kill_handler)
 signal.signal(signal.SIGTERM, kill_handler)

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -241,6 +241,7 @@ class ProtectFile:
                 break
 
             except OSError:
+                print('__init__ -> OSError:')
                 # An error happen while trying to generate the Lockfile. This raise an 
                 # OSError: [Errno 5] Input/output error!
                 # As no Lockfile remain, I assume this is cause by the Lockfile being
@@ -249,24 +250,31 @@ class ProtectFile:
                 pass
 
             except FileNotFoundError:
+                print('__init__ -> FileNotFoundError:')
                 # Lockfile could not be created, wait and try again
                 self._wait(wait)
                 pass
 
             except FileExistsError:
+                print(f'__init__ -> FileExistsError:  {max_lock_time=}')
                 # Lockfile exists, wait and try again
                 self._wait(wait)
                 if max_lock_time is not None:
                     try:
+                        print(f'__init__ -> FileExistsError:  try 1 begin')
                         kill_lock = False
                         try:
+                            print(f'__init__ -> FileExistsError:  try 2 begin')
                             with self.lockfile.open('r') as fid:
                                 info = json.load(fid)
+                            print(f'__init__ -> FileExistsError:  try 2 succed')
                         except:
+                            print(f'__init__ -> FileExistsError:  try 2 fail')
                             continue
                         if self._testing:
                             # This is only for tests, to be able to kill the process
                             time.sleep(1)
+                        print(f'__init__ -> FileExistsError:  {info=}')
                         if 'free_after' in info and int(info['free_after']) > 0 \
                         and int(info['free_after']) < time.time():
                             # We free the original process by deleting the lockfile
@@ -285,6 +293,7 @@ class ProtectFile:
                         pass
 
             except PermissionError:
+                print('__init__ -> PermissionError:')
                 # Special case: we can still access eos files when permission has expired, using `eos`
                 if isinstance(self.file, EosPath):
                     try:

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -228,24 +228,19 @@ class ProtectFile:
         self._access = False
         while True:
             try:
-                print('__init__ -> Try creating the lockfile')
                 self._create_lock(max_lock_time=max_lock_time)
                 # Success! Or is it....?
                 # We are in the lockfile, but there is still one potential concurrency,
                 # namely another process could have started creating the file while we
                 # did not see it having been created yet...
-                print('__init__ -> Creation of the lockfile OK')
                 self._flush_lock()
                 if not self._lock_is_ours():
-                    print('__init__ -> Lockfile not ours')
                     self._wait(wait)
                     continue
-                print('__init__ -> Lockfile ours')
                 self._print_debug("init", f"created {self.lockfile}")
                 break
 
             except OSError:
-                print(f'__init__ -> OSError: {self.lockfile.exists()=}')
                 # An error happen while trying to generate the Lockfile. This raise an 
                 # OSError: [Errno 5] Input/output error!
                 self._wait(wait)
@@ -269,7 +264,6 @@ class ProtectFile:
                             # gets to use the file; which is the intended behaviour
                             # (first one wins).
                             kill_lock = True
-                        print(f'__init__ -> OSError: {kill_lock=}')
                         if kill_lock:
                             self.lockfile.unlink()
                             self._print_debug("init",f"freed {self.lockfile} because "
@@ -315,7 +309,8 @@ class ProtectFile:
                     except FileNotFoundError:
                         # All is fine, the lockfile disappeared in the meanwhile.
                         # Return to the while loop.
-                        pass
+                        continue
+                continue
 
             except PermissionError:
                 # Special case: we can still access eos files when permission has expired, using `eos`

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -33,8 +33,9 @@ atexit.register(exit_handler)
 # This one should handle those exceptions.
 def kill_handler(signum, frame):
     exit_handler()
-    print(f"Signal {signum} has been raised.\n\n BackTrack:")
+    print(f"\n\nTraceback (most recent call last):")
     traceback.print_stack(frame)
+    print(f"\n{signal.Signals(signum).name}: [Errno {signum}] A signal has been raised.")
     sys.exit(0)
 signal.signal(signal.SIGINT, kill_handler)
 signal.signal(signal.SIGTERM, kill_handler)

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -241,7 +241,7 @@ class ProtectFile:
                 break
 
             except OSError:
-                print('__init__ -> OSError:')
+                print(f'__init__ -> OSError: {self.lockfile.exists()=}')
                 # An error happen while trying to generate the Lockfile. This raise an 
                 # OSError: [Errno 5] Input/output error!
                 self._wait(wait)
@@ -270,6 +270,7 @@ class ProtectFile:
                             # gets to use the file; which is the intended behaviour
                             # (first one wins).
                             kill_lock = True
+                        print(f'__init__ -> OSError:  {kill_lock=}')
                         if kill_lock:
                             self.lockfile.unlink()
                             self._print_debug("init",f"freed {self.lockfile} because "

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -3,8 +3,9 @@ This package is an attempt to make file reading/writing (possibly concurrent) mo
 
 Last update 23/03/2024 - F.F. Van der Veken
 """
-
+import sys
 import atexit
+import signal
 import datetime
 import hashlib
 import io
@@ -20,6 +21,7 @@ from .tools import ranID
 
 protected_open = {}
 
+# The functions registered via this module are not called when the program is killed by a signal not handled by Python, when a Python fatal internal error is detected, or when os._exit() is called.
 def exit_handler():
     """This handles cleaning of potential leftover lockfiles."""
     for file in protected_open.values():
@@ -27,6 +29,12 @@ def exit_handler():
     _tempdir.cleanup()
 atexit.register(exit_handler)
 
+# This one should handle those exceptions.
+# def kill_handler(*args):
+#     exit_handler()
+#     sys.exit(0)
+# signal.signal(signal.SIGINT, kill_handler)
+# signal.signal(signal.SIGTERM, kill_handler)
 
 def get_hash(filename, size=128):
     """Get a fast hash of a file, in chunks of 'size' (in kb)"""

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -268,7 +268,6 @@ class ProtectFile:
                             self.lockfile.unlink()
                             self._print_debug("init",f"freed {self.lockfile} because "
                                                 + "of exceeding max_lock_time")
-                        print(f'__init__ -> OSError: END! and continue')
                     except FileNotFoundError:
                         # All is fine, the lockfile disappeared in the meanwhile.
                         # Return to the while loop.
@@ -278,7 +277,7 @@ class ProtectFile:
             except FileNotFoundError:
                 # Lockfile could not be created, wait and try again
                 self._wait(wait)
-                pass
+                continue
 
             except FileExistsError:
                 # Lockfile exists, wait and try again

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -30,11 +30,11 @@ def exit_handler():
 atexit.register(exit_handler)
 
 # This one should handle those exceptions.
-# def kill_handler(*args):
-#     exit_handler()
-#     sys.exit(0)
-# signal.signal(signal.SIGINT, kill_handler)
-# signal.signal(signal.SIGTERM, kill_handler)
+def kill_handler(*args):
+    exit_handler()
+    sys.exit(0)
+signal.signal(signal.SIGINT, kill_handler)
+signal.signal(signal.SIGTERM, kill_handler)
 
 def get_hash(filename, size=128):
     """Get a fast hash of a file, in chunks of 'size' (in kb)"""

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -228,19 +228,24 @@ class ProtectFile:
         self._access = False
         while True:
             try:
+                print('__init__ -> Try creating the lockfile')
                 self._create_lock(max_lock_time=max_lock_time)
                 # Success! Or is it....?
                 # We are in the lockfile, but there is still one potential concurrency,
                 # namely another process could have started creating the file while we
                 # did not see it having been created yet...
+                print('__init__ -> Creation of the lockfile OK')
                 self._flush_lock()
                 if not self._lock_is_ours():
+                    print('__init__ -> Lockfile not ours')
                     self._wait(wait)
                     continue
+                print('__init__ -> Lockfile ours')
                 self._print_debug("init", f"created {self.lockfile}")
                 break
 
             except OSError:
+                print(f'__init__ -> OSError: {self.lockfile.exists()=}')
                 # An error happen while trying to generate the Lockfile. This raise an 
                 # OSError: [Errno 5] Input/output error!
                 self._wait(wait)
@@ -264,15 +269,17 @@ class ProtectFile:
                             # gets to use the file; which is the intended behaviour
                             # (first one wins).
                             kill_lock = True
+                        print(f'__init__ -> OSError: {kill_lock=}')
                         if kill_lock:
                             self.lockfile.unlink()
                             self._print_debug("init",f"freed {self.lockfile} because "
                                                 + "of exceeding max_lock_time")
+                        print(f'__init__ -> OSError: END! and continue')
                     except FileNotFoundError:
                         # All is fine, the lockfile disappeared in the meanwhile.
                         # Return to the while loop.
-                        pass
-                pass
+                        continue
+                continue
 
             except FileNotFoundError:
                 # Lockfile could not be created, wait and try again

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -232,6 +232,14 @@ class ProtectFile:
                 self._print_debug("init", f"created {self.lockfile}")
                 break
 
+            except OSError:
+                # An error happen while trying to generate the Lockfile. This raise an 
+                # OSError: [Errno 5] Input/output error!
+                # As no Lockfile remain, I assume this is cause by the Lockfile being
+                # removed while this jobs try to create it.
+                self._wait(wait)
+                pass
+
             except FileNotFoundError:
                 # Lockfile could not be created, wait and try again
                 self._wait(wait)

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -244,10 +244,9 @@ class ProtectFile:
                 print('__init__ -> OSError:')
                 # An error happen while trying to generate the Lockfile. This raise an 
                 # OSError: [Errno 5] Input/output error!
-                # As no Lockfile remain, I assume this is cause by the Lockfile being
-                # removed while this jobs try to create it.
                 self._wait(wait)
-                if max_lock_time is not None:
+                if self.lockfile.exists():
+#                 if max_lock_time is not None and self.lockfile.exists():
                     try:
                         print(f'__init__ -> OSError:  try 1 begin')
                         kill_lock = False

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -35,7 +35,7 @@ def kill_handler(signum, frame):
     exit_handler()
     print(f"\n\nTraceback (most recent call last):")
     traceback.print_stack(frame)
-    print(f"\n{signal.Signals(signum).name}: [Errno {signum}] A signal has been raised.")
+    print(f"{signal.Signals(signum).name}: [Errno {signum}] A signal has been raised.")
     sys.exit(0)
 signal.signal(signal.SIGINT, kill_handler)
 signal.signal(signal.SIGTERM, kill_handler)


### PR DESCRIPTION
…in parallel! Error source: the Lockfile creation in _create_lock.

## Description
When I run 500 simulation in parallel, I often (~10% of the ) receive mail (~10% of the number of jobs) generate by this error. As far as I know, this is not really an issue: there is no remaining Lockfile. I assume that another job remove the Lockfile while it was generated by the current job which raise this OSError.

Closes # .