### PR TITLE
Fix main

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ include = ["LICENSE", "NOTICE"]
 [tool.poetry.dependencies]
 python = ">=3.8, <3.12"
 numpy = ">=1.0"
+requests = "*"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=7.3"

--- a/xaux/protectfile.py
+++ b/xaux/protectfile.py
@@ -260,9 +260,10 @@ class ProtectFile:
                 continue
 
             except FileExistsError:
-                # Lockfile exists, wait and try again
+                # Lockfile exists, wait, check if it can be freed and try again
                 self._wait(wait)
-                if max_lock_time is not None:
+#                 if max_lock_time is not None:
+                if self.lockfile.exists():
                     try:
                         kill_lock = False
                         try:


### PR DESCRIPTION
## Description
Fix 2 issues in the main branch:
- Add `requests` as dependencies. Otherwise it will crash when imported in python
- Even if `max_lock_time` is not None, a working process should check if a lockfile is too old.

The tests were successful even with those modifications.

Closes # .
